### PR TITLE
Fix the faulty caching implementation

### DIFF
--- a/config/axiosConfiguration.ts
+++ b/config/axiosConfiguration.ts
@@ -9,9 +9,7 @@ const instance = axios.create({
   baseURL: API_URL,
 });
 
-export const axiosService = setupCache(instance, {
-  ttl: 0,
-});
+export const axiosService = setupCache(instance);
 
 export async function invalidateCache(id: string) {
   axiosService.storage.remove(id);

--- a/scripts/actions/api/auth/auth.ts
+++ b/scripts/actions/api/auth/auth.ts
@@ -33,6 +33,7 @@ export async function login(payload: UserLoginRequest): Promise<ResponseCheckerP
       { email: payload.email, password: payload.password },
       {
         hasDefaultHeaders: true,
+        cache: false,
       }
     );
 

--- a/scripts/actions/api/products/products.ts
+++ b/scripts/actions/api/products/products.ts
@@ -8,6 +8,7 @@ export async function getProducts() {
   try {
     const res = await axiosService.get("/v1/Product", {
       requiresAuth: true,
+      cache: false,
       hasDefaultHeaders: true,
     });
 
@@ -22,6 +23,7 @@ export async function deleteProduct(id: string) {
   try {
     const res = await axiosService.delete(`/v1/Product/${id}`, {
       requiresAuth: true,
+      cache: false,
       hasDefaultHeaders: true,
     });
 
@@ -37,6 +39,7 @@ export async function createProduct(formData: FormData) {
   try {
     const res = await axiosService.post("/v1/Product", formData, {
       requiresAuth: true,
+      cache: false,
       headers: {
         "Content-Type": "multipart/form-data",
       },


### PR DESCRIPTION
Fixed:
- Faulty caching implementation, by switching from setting `ttl: 0` on the axios instance to manually providing `cache: false` property to each specific API call.

The `ttl: 0` would cache the result and then delete it right after. On slow devices, It would have caused a bottleneck as well.

This information was provided by the dev team of `axios-cache-interceptor` package and therefore the fix too.
 