### PR TITLE
fix: caching and revalidation

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -6,13 +6,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { userSchema } from "@/types/validators/userValidators";
 import { validationErrorAssigner } from "@/scripts/helpers/validationErrorAssigner";
 import { login } from "@/scripts/actions/api/auth/auth";
 import { HttpStatusTypes } from "@/config/constants";
 import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
+import { AuthenticationContext } from "@/context/AuthenticationContext";
+import { invalidateUserCache } from "@/config/axiosConfiguration";
 
 export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRef<"div">) {
   const [userDetails, setUserDetails] = useState<UserLoginRequest>({
@@ -24,6 +26,7 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
     password: "",
   });
   const router = useRouter();
+  const authCtx = useContext(AuthenticationContext);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -39,6 +42,8 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
     const res = await login(userDetails);
 
     if (res.type === HttpStatusTypes.Success) {
+      await invalidateUserCache();
+      authCtx.refreshUser();
       toast.success("Welcome back!");
       router.refresh();
       return;

--- a/components/profile/profile-bar.tsx
+++ b/components/profile/profile-bar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useUser } from "@/scripts/hooks/useUser";
 import { useRouter } from "next/navigation";
-import { Avatar, AvatarImage, AvatarFallback } from "../ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 
 export default function NavigationBar() {
   const router = useRouter();
+  const user = useUser();
 
   return (
     <section className="w-full">
@@ -12,7 +14,7 @@ export default function NavigationBar() {
         <button onClick={() => router.push("/profile")}>
           <Avatar>
             <AvatarImage src="" />
-            <AvatarFallback className="border border-black">V</AvatarFallback>
+            <AvatarFallback className="border border-black">{user?.email[0].toUpperCase()}</AvatarFallback>
           </Avatar>
         </button>
       </nav>

--- a/components/profile/profile-company-card.tsx
+++ b/components/profile/profile-company-card.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { AuthenticationContext } from "@/context/AuthenticationContext";
+import { UserRole } from "@/config/constants";
+import { useUser } from "@/scripts/hooks/useUser";
 import { AtSign, Building2, IdCard, Phone, Pin } from "lucide-react";
-import { useContext } from "react";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
-import { UserRole } from "@/config/constants";
 
 export default function ProfileCompanyCard() {
-  const user = useContext(AuthenticationContext);
+  const user = useUser();
   const company = user?.company;
 
   if (!user) return null;

--- a/components/profile/profile-form.tsx
+++ b/components/profile/profile-form.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { AuthenticationContext } from "@/context/AuthenticationContext";
-import { useContext } from "react";
+import { useUser } from "@/scripts/hooks/useUser";
+import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
-import { Button } from "../ui/button";
 
 export default function ProfileForm() {
-  const user = useContext(AuthenticationContext);
+  const user = useUser();
 
   return (
     <form className="flex flex-col gap-y-4 w-full">

--- a/config/axiosConfiguration.ts
+++ b/config/axiosConfiguration.ts
@@ -11,7 +11,7 @@ const instance = axios.create({
 
 export const axiosService = setupCache(instance);
 
-export async function invalidateCache() {
+export async function invalidateUserCache() {
   await axiosService.storage.remove("getCurrentUser");
 }
 

--- a/context/AuthenticationContext.tsx
+++ b/context/AuthenticationContext.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useUser } from "@/scripts/hooks/useUser";
-import { createContext } from "react";
+import { useUser_USED_FOR_CONTEXT } from "@/scripts/helpers/useUser_USED_FOR_CONTEXT";
+import { createContext, useState } from "react";
 
-export const AuthenticationContext = createContext<User | null>(null);
+export const AuthenticationContext = createContext<{ user: User | null; refreshUser: () => void }>({ user: null, refreshUser: () => {} });
 
 export default function AuthenticationContextProvider({ children }: { children: React.ReactNode }) {
-  const user = useUser();
-  return <AuthenticationContext.Provider value={user}>{children}</AuthenticationContext.Provider>;
+  const [trigger, setTrigger] = useState(0);
+  const user = useUser_USED_FOR_CONTEXT(trigger);
+
+  function refreshUser() {
+    setTrigger((prev) => prev + 1);
+  }
+
+  return <AuthenticationContext.Provider value={{ user, refreshUser }}>{children}</AuthenticationContext.Provider>;
 }

--- a/scripts/actions/api/auth/auth.ts
+++ b/scripts/actions/api/auth/auth.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { axiosService } from "@/config/axiosConfiguration";
+import { axiosService, invalidateUserCache } from "@/config/axiosConfiguration";
 import { HttpStatusTypes } from "@/config/constants";
 import { axiosErrorHandler } from "@/scripts/helpers/axiosErrorHandler";
 import { responseValidator } from "@/scripts/helpers/responseValidator";
@@ -12,10 +12,14 @@ export async function getCurrentUser(): Promise<ResponseCheckerPayload<User | Re
   try {
     const res = await axiosService.get("/v1/users/me", {
       id: "getCurrentUser",
-      cache: false,
+      cache: {
+        ttl: 5 * 60 * 1000,
+      },
       requiresAuth: true,
       hasDefaultHeaders: true,
     });
+
+    console.log(res.cached);
 
     const validatedResponse = responseValidator<User>(res.status, res.data);
     return validatedResponse;
@@ -58,4 +62,5 @@ export async function login(payload: UserLoginRequest): Promise<ResponseCheckerP
 export async function logout() {
   const cookieStore = await cookies();
   cookieStore.delete("token");
+  await invalidateUserCache();
 }

--- a/scripts/helpers/useUser_USED_FOR_CONTEXT.ts
+++ b/scripts/helpers/useUser_USED_FOR_CONTEXT.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getCurrentUser } from "../actions/api/auth/auth";
+
+export function useUser_USED_FOR_CONTEXT(trigger: number): User | null {
+  const [user, setUser] = useState<User | null>(null);
+
+  async function fetcher() {
+    try {
+      const res = await getCurrentUser();
+      if (!("code" in res.data)) {
+        setUser(res.data as User);
+      } else {
+        setUser(null);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      setUser(null);
+    }
+  }
+
+  useEffect(() => {
+    fetcher();
+  }, [trigger]);
+
+  return user;
+}

--- a/scripts/hooks/useUser.ts
+++ b/scripts/hooks/useUser.ts
@@ -1,32 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { getCurrentUser } from "../actions/api/auth/auth";
+import { AuthenticationContext } from "@/context/AuthenticationContext";
+import { useContext } from "react";
 
 export function useUser(): User | null {
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    async function fetcher() {
-      try {
-        const res = await getCurrentUser();
-        if (!("code" in res.data)) {
-          setUser(res.data as User);
-        } else {
-          setUser(null);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
-        setUser(null);
-      }
-    }
-
-    fetcher();
-
-    return () => {
-      setUser(null);
-    };
-  }, []); //
+  const ctx = useContext(AuthenticationContext);
+  const user = ctx?.user;
 
   return user;
 }


### PR DESCRIPTION
Fixed:
- The user information was being retained after logging out, and if you tried to login with a different account, you would have to refresh the page to see your actual data.

This was fixed by using a trigger for an authentication context to re-run the getter function, ran in a `useEffect` scope.

Additionally the 5 minute cache has been applied to the endpoint, which ensures less calls to the back-end API.

